### PR TITLE
Fix: Looping logic

### DIFF
--- a/wasp/src/main/java/rrampage/wasp/Machine.java
+++ b/wasp/src/main/java/rrampage/wasp/Machine.java
@@ -481,7 +481,7 @@ public class Machine {
                             }
                         }
                         case FunctionInstruction.Return() -> {
-                            return level-1;
+                            return -1;
                         }
                         case FunctionInstruction.LocalGet l -> {
                             Variable var = locals[l.val()];
@@ -519,7 +519,6 @@ public class Machine {
                     push((cmp == 0) ? t1 : t2);
                 }
                 case ControlFlowInstruction i -> {
-                    // TODO - Verify block instruction
                     var currLevel = level;
                     switch (i) {
                         case ControlFlowInstruction.Block b -> {
@@ -530,9 +529,9 @@ public class Machine {
                         }
                         case ControlFlowInstruction.Loop b -> {
                             do {
-                                System.out.println("Level:" + level + ", currLevel: " + b.label());
+                                System.out.println("Level:" + level + ", label: " + b.label());
                                 level = execute(b.code(), locals, b.label());
-                                System.out.println("Level:" + level + ", currLevel: " + b.label());
+                                System.out.println("Level:" + level + ", label: " + b.label());
                             } while (level == b.label());
                         }
                         case ControlFlowInstruction.Branch b -> {

--- a/wasp/src/main/java/rrampage/wasp/data/Function.java
+++ b/wasp/src/main/java/rrampage/wasp/data/Function.java
@@ -7,7 +7,7 @@ import rrampage.wasp.instructions.FunctionInstruction;
 import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 
-public record Function(String name, FunctionType type, ValueType[] locals, Instruction[] code, int[] labels) {
+public record Function(String name, FunctionType type, ValueType[] locals, Instruction[] code) {
     public boolean isVoidReturn() {
         return type().isVoidReturn();
     }
@@ -48,7 +48,7 @@ public record Function(String name, FunctionType type, ValueType[] locals, Instr
     }
 
     public static Function createStubFunction(String name, FunctionType type) {
-        return new Function(name, type, null, new Instruction[]{}, null);
+        return new Function(name, type, null, new Instruction[]{});
     }
 
     public static Function createImportFunction(String name, FunctionType type, MethodHandle func) {
@@ -56,10 +56,10 @@ public record Function(String name, FunctionType type, ValueType[] locals, Instr
         if (!func.type().equals(FunctionType.getMethodTypeFromFunctionType(type))) {
             throw new RuntimeException(String.format("CREATE_IMPORT_FUNCTION: Invalid type %s supplied for Function %s. Required type: %s", func.type(), name, type));
         }
-        return new Function(name, type, null, new Instruction[]{new FunctionInstruction.CallJava(type, func)}, null);
+        return new Function(name, type, null, new Instruction[]{new FunctionInstruction.CallJava(type, func)});
     }
 
     public static Function createStartFunction(String name, Instruction[] code) {
-        return new Function(name, new FunctionType(null, null), null, code, getLabelsFromInstructions(code));
+        return new Function(name, new FunctionType(null, null), null, code);
     }
 }

--- a/wasp/src/main/java/rrampage/wasp/parser/WasmParser.java
+++ b/wasp/src/main/java/rrampage/wasp/parser/WasmParser.java
@@ -344,7 +344,7 @@ public class WasmParser implements Parser {
         Instruction[] code = InstructionParser.parse(bb, bytesToParse, types);
         System.out.println("Code : " + Arrays.toString(code));
         String fname = "Function_" + funcIdx;
-        Function f = new Function(fname, types[functions[funcIdx - numImports]], locals.toArray(ValueType[]::new), code, Function.getLabelsFromInstructions(code));
+        Function f = new Function(fname, types[functions[funcIdx - numImports]], locals.toArray(ValueType[]::new), code);
         byte endByte = bb.get();
         assert endByte == 0xb;
         assertBufferPosition(funPos + funSize);

--- a/wasp/src/main/java/rrampage/wasp/parser/WatParser.java
+++ b/wasp/src/main/java/rrampage/wasp/parser/WatParser.java
@@ -275,7 +275,7 @@ public record WatParser(String input) implements Parser {
             throw new RuntimeException("Type index in module does not match" + ft + " " + type);
         }
         // TODO Fill labels correctly from block/loop instructions
-        return new Function(funcName, type, locals.toArray(new ValueType.NumType[]{}), code, null);
+        return new Function(funcName, type, locals.toArray(new ValueType.NumType[]{}), code);
     }
 
     private List<ValueType.NumType> parseDataTypes(String term, ConsList cl) {

--- a/wasp/src/test/java/rrampage/wasp/MachineTest.java
+++ b/wasp/src/test/java/rrampage/wasp/MachineTest.java
@@ -22,7 +22,7 @@ public class MachineTest {
                     new FunctionInstruction.LocalGet(0),
                     new FunctionInstruction.LocalGet(1),
                     IntBinaryInstruction.I32_ADD
-            }, null);
+            });
 
     @Test
     public void shouldPushConst() {
@@ -176,7 +176,7 @@ public class MachineTest {
     @Test
     public void shouldCallIntConstFunction() {
         int i = 42;
-        Function fun = new Function("const", new FunctionType(null, new ValueType.NumType[]{ValueType.NumType.I32}), null, new Instruction[]{new ConstInstruction.IntConst(i)}, null);
+        Function fun = new Function("const", new FunctionType(null, new ValueType.NumType[]{ValueType.NumType.I32}), null, new Instruction[]{new ConstInstruction.IntConst(i)});
         Instruction[] ins = new Instruction[] {
           new FunctionInstruction.Call(0)
         };
@@ -211,10 +211,10 @@ public class MachineTest {
                 new GlobalInstruction.GlobalGet(0),
                 new ConstInstruction.IntConst(10),
                 IntBinaryInstruction.I32_LT_S,
-                new ControlFlowInstruction.BranchIf(1),
+                new ControlFlowInstruction.BranchIf(0),
         };
         Instruction[] ins = new Instruction[] {
-                new ControlFlowInstruction.Loop(1, null, loopIns),
+                new ControlFlowInstruction.Loop(0, null, loopIns),
                 new GlobalInstruction.GlobalGet(0),
         };
         Machine m = Machine.createAndStart(new Function[]{Function.createStartFunction("shouldLoopGlobal", ins)}, null, globals, MEM_PAGES, null, null, 0);
@@ -240,7 +240,7 @@ public class MachineTest {
         int[] labels = Function.getLabelsFromInstructions(funIns);
         assertArrayEquals(new int[]{-1, -1}, labels);
         Function f = new Function("loop_check", new FunctionType(null, null),
-                new ValueType.NumType[]{ValueType.NumType.I32}, funIns, labels);
+                new ValueType.NumType[]{ValueType.NumType.I32}, funIns);
         Instruction[] ins = new Instruction[] {
                 new ConstInstruction.IntConst(0),
                 new FunctionInstruction.Call(0),
@@ -282,7 +282,7 @@ public class MachineTest {
         Instruction[] funIns = new Instruction[]{
                 new FunctionInstruction.CallJava(type, mh),
         };
-        Function fun = new Function("pow", type, null, funIns, null);
+        Function fun = new Function("pow", type, null, funIns);
         Instruction[] ins = new Instruction[]{
                 new ConstInstruction.DoubleConst(b),
                 new ConstInstruction.DoubleConst(a),

--- a/wasp/src/test/java/rrampage/wasp/WasmRunnerTest.java
+++ b/wasp/src/test/java/rrampage/wasp/WasmRunnerTest.java
@@ -3,7 +3,10 @@ import org.junit.jupiter.api.Test;
 import rrampage.wasp.data.FunctionType;
 import rrampage.wasp.data.Module;
 import rrampage.wasp.data.ValueType;
+import rrampage.wasp.data.Variable;
 import rrampage.wasp.instructions.ConstInstruction;
+import rrampage.wasp.instructions.ControlFlowInstruction;
+import rrampage.wasp.instructions.Instruction;
 import rrampage.wasp.parser.WasmParser;
 import rrampage.wasp.utils.ImportUtils;
 
@@ -55,8 +58,10 @@ public class WasmRunnerTest {
     public void shouldRunFactorial() {
         var module = parseModule("./testsuite/fac.0.wasm");
         var machine = module.instantiate(null);
-        /*machine.invoke("fac-iter", ConstInstruction.of(new ConstInstruction.LongConst(3)));
-        assertEquals(6L, machine.pop());*/
+        machine.invoke("fac-iter", ConstInstruction.of(new ConstInstruction.LongConst(25)));
+        assertEquals(7034535277573963776L, machine.pop());
+        machine.invoke("fac-iter-named", ConstInstruction.of(new ConstInstruction.LongConst(25)));
+        assertEquals(7034535277573963776L, machine.pop());
         machine.invoke("fac-rec", ConstInstruction.of(new ConstInstruction.LongConst(25)));
         assertEquals(7034535277573963776L, machine.pop());
         machine.invoke("fac-rec-named", ConstInstruction.of(new ConstInstruction.LongConst(25)));


### PR DESCRIPTION
Changes:
- WASM jumps are structured goto
- It is only possible to jump outwards
- Jumps are restricted to function body only
- Assume that function starts at nested level of -1. 
  - This plays nice with the label indexes for structured control flow instructions which start at 0.
  - This also means that we do not need a `labels` array to save /restore after every function call. Within context of a function call, a level can only have one value
- Jumps to `block` label will always go to end of the block. If level returned is equal to the block's label value, we return from the `execute` method i.e jump to end of block 
- Jumps to `loop` label will always go to start of the block. We keep executing the instructions inside the block till returned level is no longer equal to the label
- `return` will return a value of `-1` as it signals end of function execution
- For `If` and `IfElse`, we check the returned level. If it does not equal original level, we return