### PR TITLE
Supporting Assert return from WAST test-suite

### DIFF
--- a/wasp/src/main/java/rrampage/wasp/utils/ConversionUtils.java
+++ b/wasp/src/main/java/rrampage/wasp/utils/ConversionUtils.java
@@ -1,5 +1,7 @@
 package rrampage.wasp.utils;
 
+import rrampage.wasp.instructions.ConstInstruction;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -102,4 +104,9 @@ public class ConversionUtils {
     public static <K, V> Map<K, V> convertArrayToImmutableMap(V[] arr, Function<V, K> func) {
          return Map.copyOf(Arrays.stream(arr).collect(Collectors.toMap(func::apply, v -> v)));
     }
+
+    public static ConstInstruction.IntConst constOf(int val) {return new ConstInstruction.IntConst(val);}
+    public static ConstInstruction.LongConst constOf(long val) {return new ConstInstruction.LongConst(val);}
+    public static ConstInstruction.FloatConst constOf(float val) {return new ConstInstruction.FloatConst(val);}
+    public static ConstInstruction.DoubleConst constOf(double val) {return new ConstInstruction.DoubleConst(val);}
 }

--- a/wasp/src/test/java/rrampage/wasp/FactorialTest.java
+++ b/wasp/src/test/java/rrampage/wasp/FactorialTest.java
@@ -1,0 +1,40 @@
+package rrampage.wasp;
+
+import org.junit.jupiter.api.*;
+import rrampage.wasp.data.AssertReturn;
+import rrampage.wasp.data.Module;
+import rrampage.wasp.instructions.*;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static rrampage.wasp.TestUtils.*;
+import static rrampage.wasp.utils.ConversionUtils.constOf;
+
+public class FactorialTest {
+    private static final AssertReturn[] assertReturnTestCases = new AssertReturn[] {
+            new AssertReturn("fac-iter", ConstInstruction.of(constOf(25L)), ConstInstruction.of(constOf(7034535277573963776L))),
+            new AssertReturn("fac-iter-named", ConstInstruction.of(constOf(25L)), ConstInstruction.of(constOf(7034535277573963776L))),
+            new AssertReturn("fac-rec", ConstInstruction.of(constOf(25L)), ConstInstruction.of(constOf(7034535277573963776L))),
+            new AssertReturn("fac-rec-named", ConstInstruction.of(constOf(25L)), ConstInstruction.of(constOf(7034535277573963776L))),
+            new AssertReturn("fac-opt", ConstInstruction.of(constOf(25L)), ConstInstruction.of(constOf(7034535277573963776L))),
+            new AssertReturn("fac-ssa", ConstInstruction.of(constOf(25L)), ConstInstruction.of(constOf(7034535277573963776L))),
+    };
+    Module module = parseModule("./testsuite/fac.0.wasm");
+    Machine machine = module.instantiate(null);
+
+    public void check(AssertReturn test) {
+        assertTrue(invokeAndCheckStack(machine, test.function(), test.args(), test.expected()));
+    }
+
+    @Test()
+    @Tag("high-resource")
+    public void shouldRunFactorialAndThrowStackOverflowException() {
+        assertThrows(StackOverflowError.class, () -> machine.invoke("fac-rec", ConstInstruction.of(constOf(1073741824))));
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> test() {
+        return DynamicTest.stream(Stream.of(assertReturnTestCases), AssertReturn::function, this::check);
+    }
+}

--- a/wasp/src/test/java/rrampage/wasp/TestUtils.java
+++ b/wasp/src/test/java/rrampage/wasp/TestUtils.java
@@ -1,5 +1,8 @@
 package rrampage.wasp;
 
+import rrampage.wasp.data.Module;
+import rrampage.wasp.instructions.ConstInstruction;
+import rrampage.wasp.parser.WasmParser;
 import rrampage.wasp.utils.FileUtils;
 
 import java.io.IOException;
@@ -26,5 +29,14 @@ public class TestUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static Module parseModule(String fileName) {
+        return new WasmParser(readBinaryFile(getFilePath(fileName))).parseModule();
+    }
+
+    public static boolean invokeAndCheckStack(Machine m, String function, ConstInstruction[] args, ConstInstruction[] expected) {
+        m.invoke(function, args);
+        return m.compareStack(expected);
     }
 }

--- a/wasp/src/test/java/rrampage/wasp/WasmParserTest.java
+++ b/wasp/src/test/java/rrampage/wasp/WasmParserTest.java
@@ -48,5 +48,4 @@ public class WasmParserTest {
     public Stream<DynamicTest> testWasmParser() {
         return DynamicTest.stream(Stream.of(testCases), WasmParserTestCase::fileName, WasmParserTestCase::check);
     }
-
 }

--- a/wasp/src/test/java/rrampage/wasp/WasmRunnerTest.java
+++ b/wasp/src/test/java/rrampage/wasp/WasmRunnerTest.java
@@ -1,26 +1,19 @@
 package rrampage.wasp;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import rrampage.wasp.data.FunctionType;
-import rrampage.wasp.data.Module;
 import rrampage.wasp.data.ValueType;
 import rrampage.wasp.instructions.ConstInstruction;
-import rrampage.wasp.parser.WasmParser;
 import rrampage.wasp.utils.ImportUtils;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static rrampage.wasp.TestUtils.getFilePath;
-import static rrampage.wasp.TestUtils.readBinaryFile;
+import static rrampage.wasp.TestUtils.*;
+import static rrampage.wasp.utils.ConversionUtils.constOf;
 
 public class WasmRunnerTest {
     private static final long[] EMPTY_STACK = new long[]{};
-
-    private Module parseModule(String fileName) {
-        return new WasmParser(readBinaryFile(getFilePath(fileName))).parseModule();
-    }
 
     @Test
     public void shouldRunEmptyModule() {
@@ -55,39 +48,10 @@ public class WasmRunnerTest {
     }
 
     @Test
-    public void shouldRunFactorial() {
-        var module = parseModule("./testsuite/fac.0.wasm");
-        var machine = module.instantiate(null);
-        machine.invoke("fac-iter", ConstInstruction.of(new ConstInstruction.LongConst(25)));
-        assertEquals(7034535277573963776L, machine.pop());
-        machine.invoke("fac-iter-named", ConstInstruction.of(new ConstInstruction.LongConst(25)));
-        assertEquals(7034535277573963776L, machine.pop());
-        machine.invoke("fac-rec", ConstInstruction.of(new ConstInstruction.LongConst(25)));
-        assertEquals(7034535277573963776L, machine.pop());
-        machine.invoke("fac-rec-named", ConstInstruction.of(new ConstInstruction.LongConst(25)));
-        assertEquals(7034535277573963776L, machine.pop());
-        machine.invoke("fac-opt", ConstInstruction.of(new ConstInstruction.LongConst(25)));
-        assertEquals(7034535277573963776L, machine.pop());
-        machine.invoke("fac-ssa", ConstInstruction.of(new ConstInstruction.LongConst(25)));
-        assertEquals(7034535277573963776L, machine.pop());
-    }
-
-    @Test()
-    @Tag("high-resource")
-    public void shouldRunFactorialAndThrowStackOverflowException() {
-        // Following has been tested. Disabling to prevent CI mem limit errors
-        var module = parseModule("./testsuite/fac.0.wasm");
-        var machine = module.instantiate(null);
-        assertThrows(StackOverflowError.class, () -> machine.invoke("fac-rec", ConstInstruction.of(new ConstInstruction.LongConst(1073741824))));
-    }
-
-    @Test
     public void shouldHandleMultipleReturn() {
         var module = parseModule("./reduced_loop.wasm");
         var machine = module.instantiate(null);
-        machine.invoke("break-br_if-num-num", ConstInstruction.of(new ConstInstruction.IntConst(0)));
-        assertArrayEquals(new long[]{51, 52}, machine.inspectStack());
-        machine.invoke("break-br_if-num-num", ConstInstruction.of(new ConstInstruction.IntConst(1)));
-        assertArrayEquals(new long[]{50, 51}, machine.inspectStack());
+        assertTrue(invokeAndCheckStack(machine, "break-br_if-num-num", ConstInstruction.of(constOf(0)), ConstInstruction.of(constOf(51),constOf(52))));
+        assertTrue(invokeAndCheckStack(machine, "break-br_if-num-num", ConstInstruction.of(constOf(1)), ConstInstruction.of(constOf(50),constOf(51))));
     }
 }

--- a/wasp/src/test/java/rrampage/wasp/data/AssertReturn.java
+++ b/wasp/src/test/java/rrampage/wasp/data/AssertReturn.java
@@ -1,0 +1,5 @@
+package rrampage.wasp.data;
+
+import rrampage.wasp.instructions.ConstInstruction;
+
+public record AssertReturn(String function, ConstInstruction[] args, ConstInstruction[] expected) {}


### PR DESCRIPTION
Changes:
- `Machine.compareStack()` function which takes array of expected values and generates functions to compare with stack values.
- Static method to return Const instructions in order to reduce boilerplate
- Utility method in `TestUtil` to invoke function and check stack. 1 to 1 translation of `assert-return` in WAST file
- Dynamic test case factory for checking factorial returns