### PR TITLE
Memory and Stack Changes

### DIFF
--- a/wasp/src/main/java/rrampage/wasp/data/Memory.java
+++ b/wasp/src/main/java/rrampage/wasp/data/Memory.java
@@ -31,7 +31,7 @@ public class Memory {
         this.maxPages = maxPages;
         this.memory = new byte[pages * MEM_PAGE_SIZE];
         this.isShared = isShared;
-        this.buffer = ByteBuffer.wrap(memory).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN);
+        this.buffer = ByteBuffer.wrap(memory).order(ByteOrder.LITTLE_ENDIAN);
     }
 
     public int getMemorySize() {
@@ -49,16 +49,54 @@ public class Memory {
         byte[] newMemory = new byte[(currPages+numPages)*MEM_PAGE_SIZE];
         System.arraycopy(memory, 0, newMemory, 0, memory.length);
         memory = newMemory;
-        buffer = ByteBuffer.wrap(memory).asReadOnlyBuffer().order(ByteOrder.LITTLE_ENDIAN);
+        buffer = ByteBuffer.wrap(memory).order(ByteOrder.LITTLE_ENDIAN);
         return currPages;
+    }
+
+    public byte loadByte(int addr) {
+        return buffer.get(addr);
+    }
+    public short loadShort(int addr) {
+        return buffer.getShort(addr);
+    }
+    public int loadInt(int addr) {
+        return buffer.getInt(addr);
+    }
+    public long loadLong(int addr) {
+        return buffer.getLong(addr);
+    }
+    public float loadFloat(int addr) {
+        return buffer.getFloat(addr);
+    }
+    public double loadDouble(int addr) {
+        return buffer.getDouble(addr);
     }
 
     public byte[] load(int addr, int offset) {
         return Arrays.copyOfRange(memory, addr, addr + offset);
     }
 
+    public void store(int addr, long data) {
+        buffer.putLong(addr, data);
+    }
+    public void store(int addr, int data) {
+        buffer.putInt(addr, data);
+    }
+    public void store(int addr, float data) {
+        buffer.putFloat(addr, data);
+    }
+    public void store(int addr, double data) {
+        buffer.putDouble(addr, data);
+    }
+    public void store(int addr, byte data) {
+        buffer.put(addr, data);
+    }
+    public void store(int addr, short data) {
+        buffer.putShort(addr, data);
+    }
+
     public void store(int addr, byte[] data) {
-        store(addr, data, 0, data.length);
+        buffer.put(addr, data);
     }
 
     public void store(int addr, byte[] data, int srcOffset, int numBytes) {
@@ -68,7 +106,7 @@ public class Memory {
         if (srcOffset + numBytes > data.length) {
             throw new RuntimeException("Can not copy more than source byte array size");
         }
-        System.arraycopy(data, srcOffset, memory, addr, numBytes);
+        buffer.put(addr, data, srcOffset, numBytes);
     }
 
     public void fill(int addr, byte data, int numBytes) {

--- a/wasp/src/main/java/rrampage/wasp/vm/MachineStack.java
+++ b/wasp/src/main/java/rrampage/wasp/vm/MachineStack.java
@@ -15,9 +15,9 @@ public class MachineStack {
     }
 
     public long pop() {
-        if (stackPointer <= 0) {
+        /*if (stackPointer <= 0) {
             throw new RuntimeException("STACK_UNDERFLOW");
-        }
+        }*/
         return array[--stackPointer];
     }
 

--- a/wasp/src/main/java/rrampage/wasp/vm/MachineStack.java
+++ b/wasp/src/main/java/rrampage/wasp/vm/MachineStack.java
@@ -7,11 +7,19 @@ public class MachineStack {
     private int stackPointer = 0;
 
     public void push(long value) {
+        /*
         int l = array.length;
         if (l <= stackPointer) {
             array = Arrays.copyOf(array, (int) (l * 1.5));
         }
         array[stackPointer++] = value;
+        */
+        try {
+            array[stackPointer++] = value;
+        } catch (ArrayIndexOutOfBoundsException e) {
+            array = Arrays.copyOf(array, (int) (array.length * 1.5));
+            array[stackPointer++] = value;
+        }
     }
 
     public long pop() {
@@ -51,11 +59,14 @@ public class MachineStack {
     }
 
     public static void main(String[] args) {
-        MachineStack ms = new MachineStack();
-        ms.push(1);
-        ms.push(11);
-        ms.push(111);
-        ms.dropKeep(1, 1);
-        System.out.println(ms.inspect());
+        for (int j = 0; j < 20; j++) {
+            MachineStack ms = new MachineStack();
+            var ts = System.nanoTime();
+            var n = 100_000_000;
+            for (int i = 0; i < n; i++) {
+                ms.push(111);
+            }
+            System.out.println(STR."Time: \{(System.nanoTime() - ts)/1_000_000}");
+        }
     }
 }

--- a/wasp/src/test/java/rrampage/wasp/gfx/RaymarcherProcessing.java
+++ b/wasp/src/test/java/rrampage/wasp/gfx/RaymarcherProcessing.java
@@ -29,7 +29,7 @@ public class RaymarcherProcessing extends ProcessingMachine {
         int baseAddr = 64000;
         for (int i = 0; i < 256; i++) {
             int col = i + (i<<8) + (i<<16) + 0xff000000;
-            memory.store(baseAddr + i*4, intToBytes(col));
+            memory.store(baseAddr + i*4, col);
         }
     }
 


### PR DESCRIPTION
Summary:
- Convert most load/store array operations to byte buffer operations to prevent intermediate object generation during conversion to/from primitives
- Expose ByteBuffer of memory directly as a write byte buffer
- Eliminate stack bounds check on `pop`
- Resize stack on `push` only when array out of bounds exception is thrown